### PR TITLE
Hotfix moving door & gameboard render

### DIFF
--- a/src/game/Gameboard.java
+++ b/src/game/Gameboard.java
@@ -78,12 +78,15 @@ public class Gameboard {
 				// Mostly, the player will be walking on floor, makes sense to have this first
 				if (!isPlayerOnDoor) {
 					// Move the character on the board
-					fixPreviousTile(y + move, x, CHARACTER);
 					fixPreviousTile(y, x, FLOOR);
+					fixPreviousTile(y + move, x, CHARACTER);
 				} else {
+					if (boardGrid[y + move][x].getTileType() == DOOR)
+						fixPreviousTile(y, x, FLOOR);
+					else
+						fixPreviousTile(y, x, DOOR);
 					// Move the character on the board
 					fixPreviousTile(y + move, x, CHARACTER);
-					fixPreviousTile(y, x, DOOR);
 				}
 				// Update the players coordinates
 				player.movePlayer(boardGrid[y + move][x]);
@@ -100,10 +103,8 @@ public class Gameboard {
 	public boolean onCollision(Point p) {
 		if (p.getTileType() == WALL) {
 			return true; // Can't move, wall in the way
-		} else if (p.getTileType() == MONSTER) {
-			// Returns true to show that character really stepped onto monster
-			player.setAlive(false);			
-			// Game is over
+		} else if (p.getTileType() == MONSTER) {			
+			player.setAlive(false);	
 			return true;
 		} else if (p.getTileType() == TREASURE) {
 			player.setTreasure(1);

--- a/src/game/ui/drawGameboard.java
+++ b/src/game/ui/drawGameboard.java
@@ -23,7 +23,7 @@ public class drawGameboard extends JPanel {
         this.BOARD = board;
         setUpImages();
         Timer timer = new Timer(DELAY, (final ActionEvent e) -> {
-            if (!BOARD.getIsAlive()) {
+            if (!BOARD.getPlayer().getAlive()) {
                 JOptionPane.showConfirmDialog(this, "LOL U DEDD!!!!!");
                 System.exit(0);
             }

--- a/tests/GameLogicTests.java
+++ b/tests/GameLogicTests.java
@@ -1,6 +1,5 @@
 import game.Direction;
 import game.Gameboard;
-import game.Player;
 
 import static game.TileType.*;
 import static game.Direction.*;
@@ -184,19 +183,19 @@ public class GameLogicTests {
 	}
 
 	@Test
-	public void testPersistanceOfDoorWhenPlayerMovesOverIT() {
+	@Parameters(method = "parametersFortestPersistanceOfDoorWhenPlayerMovesOverIT")
+	public void testPersistanceOfDoorWhenPlayerMovesOverIT(Direction[] direction) {
 		// Arrange
 		Gameboard board = new Gameboard();
-		Point door = board.getPoint(9, 2);
+		Point door = board.getPoint(board.getPlayer().getY(), board.getPlayer().getX()+1);
 
 		door.setTileType(DOOR);
-
+		//direction = (Direction[]) direction;
 		// Act
-		// Move onto the Door
-		board.moveCharacter(RIGHT);
-
-		// Move away from the door
-		board.moveCharacter(RIGHT);
+		// Move onto the Door and past it
+		for (int i = 0; i < direction.length; i++) {
+			board.moveCharacter(direction[i]);
+		}
 
 		boolean isPointStillDoor = false;
 		if (door.getTileType() == DOOR)
@@ -205,6 +204,16 @@ public class GameLogicTests {
 		// Assert
 		assertTrue(isPointStillDoor);
 
+	}	
+	
+	@SuppressWarnings({"unused"})
+	private Object[] parametersFortestPersistanceOfDoorWhenPlayerMovesOverIT() {
+		return new Object[] {
+		new Direction[] {RIGHT, RIGHT},
+		new Direction[] {UP,RIGHT,DOWN,DOWN},
+		new Direction[] {DOWN, RIGHT, UP, UP},
+		new Direction[] {DOWN, RIGHT, RIGHT, UP, LEFT, LEFT}
+		};
 	}
 
 	@Test
@@ -220,4 +229,6 @@ public class GameLogicTests {
 		// Assert
 		assertFalse(g.getPlayer().getAlive());
 	}
+	
+	
 }

--- a/tests/GuiTests.java
+++ b/tests/GuiTests.java
@@ -18,21 +18,12 @@ public class GuiTests {
     }
 
     @Test
-    public void testMoveCharacter() {
-        Gameboard board = new Gameboard();
-        Point charPos = board.getCharacterPosition();
-        board.moveCharacter(Direction.RIGHT);
-        Point newCharPos = board.getCharacterPosition();
-        assertNotEquals(charPos, newCharPos);
-    }
-
-    @Test
     public void testSwingRightKeyMovesCharacterRight() {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 MainWindow ui = new MainWindow();
                 Gameboard board = ui.getBoard();
-                Point charPos = board.getCharacterPosition();
+                Point charPos = board.getPlayer().get;
                 ui.requestFocus();
                 KeyEvent rArrow = new KeyEvent(ui.getComponent(0), 0, System.currentTimeMillis(), 0, KeyEvent.VK_RIGHT, KeyEvent.CHAR_UNDEFINED); 
                 ui.getComponent(0).getComponentAt(0, 0).dispatchEvent(rArrow);


### PR DESCRIPTION
Doors no longer switch places with player when player has no treasure.